### PR TITLE
Fix ulimit core file size option

### DIFF
--- a/challenge11/challenge11.md
+++ b/challenge11/challenge11.md
@@ -318,7 +318,7 @@ As expected: We see the NOP sled, and the shellcode after starting at address `0
 
 To debug it, we need to enable core files first with:
 ```
-~/challenges/challenge11$ ulimit -n unlimited
+~/challenges/challenge11$ ulimit -c unlimited
 ```
 
 Lets test the exploit without starting it under GDB:


### PR DESCRIPTION
Hello,

setting the correct option for setting the core dump as '-c'.

